### PR TITLE
Fix `[compat]` entries in `Project.toml`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,10 +10,10 @@ Primes = "27ebfcd6-29c5-5fa9-bf4b-fb8fc14df3ae"
 
 [compat]
 julia = "1"
-JuMP = "0"
-MathProgBase = "0"
-Primes = "0"
-ChooseOptimizer = "0"
+JuMP = "0.18, 0.19, 0.20, 0.21"
+MathProgBase = "0.7"
+Primes = "0.4, 0.5"
+ChooseOptimizer = "0.1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
In the General registry, we now **strongly** discourage users from having `[compat]` entries of the form:
```toml
SomePackage = "0"
```

These `[compat]` entries are problematic because they include an infinite number of breaking releases.

This pull request fixes the `[compat]` entries in the `Project.toml` file for this package.

cc: @scheinerman